### PR TITLE
Fix wrong docker python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 FROM tensorflow/tensorflow:nightly-py3
 
 RUN apt-get update -y && apt-get upgrade -y 


### PR DESCRIPTION
For receipt-parser-core versions > 0.2.1 python >= 3.7 is required